### PR TITLE
Add error handling for microphone denial.

### DIFF
--- a/src/app/simulator/page.tsx
+++ b/src/app/simulator/page.tsx
@@ -38,14 +38,20 @@ interface RealtimeEvent {
   [key: string]: unknown;
 }
 
+interface MicrophoneState {
+  isBlocked: boolean;
+  errorMessage?: string;
+}
+
 export default function SimulatorPage() {
   const [peerConnection, setPeerConnection] = useState<RTCPeerConnection | null>(null);
   const [isRecording, setIsRecording] = useState(false);
   const [dataChannel, setDataChannel] = useState<RTCDataChannel | null>(null);
-  const [permissionError, setPermissionError] = useState<string | null>("Enable your microphone to start recording");
+  const [microphoneState, setMicrophoneState] = useState<MicrophoneState>({ 
+    isBlocked: false, 
+  });
 
   const handleRecordingToggle = async () => {
-    setPermissionError(null);
     if (!isRecording) {
         if (peerConnection) {
           // TODO: if we already have a peer connection we are resuming a recording. Add handlers for pausing and resuming session.
@@ -86,19 +92,32 @@ export default function SimulatorPage() {
     console.log('Processing event:', event.type, event);
   }
 
+  // Immediately request mic access after page load to reduce error state chances.
+  useEffect(() => {
+    requestMicrophoneAccess();
+  }, []);
+
   const requestMicrophoneAccess = async () => {
     try {
-      // TODO: Consider caching this stream as a state variable or creating a RTCPeerConnection here directly. that way we can visualize just single audio. 
       await navigator.mediaDevices.getUserMedia({ audio: true });
-      setPermissionError(null);
+      setMicrophoneState({ isBlocked: false });
     } catch (err) {
       if (err instanceof Error) {
         if (err.name === 'NotAllowedError') {
-          setPermissionError('Microphone access was denied. Please allow microphone access to use this feature.');
+          setMicrophoneState({ 
+            isBlocked: true, 
+            errorMessage: 'Microphone access was denied. Please allow microphone access to use this feature.' 
+          });
         } else if (err.name === 'NotFoundError') {
-          setPermissionError('No microphone found. Please connect a microphone and try again.');
+          setMicrophoneState({ 
+            isBlocked: true, 
+            errorMessage: 'No microphone found. Please connect a microphone and try again.' 
+          });
         } else {
-          setPermissionError('An error occurred while accessing the microphone. Please try again.');
+          setMicrophoneState({ 
+            isBlocked: true, 
+            errorMessage: 'An error occurred while accessing the microphone. Please try again.' 
+          });
         }
       }
     }
@@ -109,12 +128,12 @@ export default function SimulatorPage() {
     <div className="min-h-screen bg-background dark">
       <main className="container mx-auto p-8 flex flex-col h-[calc(100vh-4rem)]">
         <div className="flex-1 bg-muted/50 rounded-lg p-4">
-          {peerConnection && <AudioVisualizer peerConnection={peerConnection} />}
-          {!peerConnection && (
+          {peerConnection && !microphoneState.isBlocked && <AudioVisualizer peerConnection={peerConnection} />}
+          {!peerConnection && microphoneState.isBlocked && (
             <div className="flex items-center justify-center h-full">
               <div className="text-center">
                 <p className="text-muted-foreground mb-4">
-                  {permissionError}
+                  {microphoneState.errorMessage}
                 </p>
                 <Button 
                     variant="secondary" 
@@ -136,6 +155,7 @@ export default function SimulatorPage() {
                     size="default"
                     className={`bg-accent hover:bg-accent/90 transition-all duration-300 ${isRecording ? "h-12 w-12 rounded-lg" : "h-16 w-16 rounded-full"}`}
                     onClick={handleRecordingToggle}
+                    disabled={microphoneState.isBlocked}
                   >
                   </Button>
                 </TooltipTrigger>


### PR DESCRIPTION
Expected behavior:
- User is prompted to enable microphone access when they first load the page.
- If user denies access, we show a message and disable the recording button.
- Once we have mic access, we show the audio visualizer and enable the recording button.

Note, if the user changes their permissions during a recording or session, we will not be handling that error case since the browser already have messaging for the user to reload the page. Error state now looks like this: 
![Screenshot 2025-01-27 at 9 21 44 AM](https://github.com/user-attachments/assets/d1857ef0-c782-4b19-a0b8-55b4eca8d9d3)
